### PR TITLE
Fix prerequisite script related issues found in integrating testing

### DIFF
--- a/Scripts/PEMCertCreationPolicy.json
+++ b/Scripts/PEMCertCreationPolicy.json
@@ -1,0 +1,38 @@
+﻿{
+  "issuerParameters": {
+    "certificateTransparency": null,
+    "name": "Self"
+  },
+  "keyProperties": {
+    "curve": null,
+    "exportable": true,
+    "keySize": 2048,
+    "keyType": "RSA",
+    "reuseKey": true
+  },
+  "lifetimeActions": [
+    {
+      "action": {
+        "actionType": "AutoRenew"
+      },
+      "trigger": {
+        "daysBeforeExpiry": 90
+      }
+    }
+  ],
+  "secretProperties": {
+    "contentType": "application/x-pem-file"
+  },
+  "x509CertificateProperties": {
+    "keyUsage": [
+      "cRLSign",
+      "dataEncipherment",
+      "digitalSignature",
+      "keyEncipherment",
+      "keyAgreement",
+      "keyCertSign"
+    ],
+    "subject": "CN=CLIGetDefaultPolicy",
+    "validityInMonths": 12
+  }
+}

--- a/Scripts/Prerequisite.ps1
+++ b/Scripts/Prerequisite.ps1
@@ -69,8 +69,7 @@ try {
   }
 
   Write-Host "Creating selfsigned certificate in keyvault ..." -ForegroundColor White
-  az keyvault certificate get-default-policy | Out-File -Encoding utf8 defaultpolicy.json
-  az keyvault certificate create --vault-name $keyVaultName -n $certName  --policy `@defaultpolicy.json
+  az keyvault certificate create --vault-name $keyVaultName -n $certName  --policy `@PEMCertCreationPolicy.json
   az keyvault certificate download --vault-name $keyVaultName -n $certName -f cert.pem
 
   Write-Host "Creating App registration ..." -ForegroundColor White
@@ -89,7 +88,7 @@ try {
   $spId = az ad sp list --display-name $servicePrincipalName --query [0].appId
 
   Write-Host "Adding ServicePrincipal to keyvault access policies ..." -ForegroundColor White
-  $objectId = az ad app show  --id $spId  --query 'objectId'
+  $objectId = az ad sp show  --id $spId  --query 'objectId'
   az keyvault set-policy --name $keyVaultName --object-id $objectId  --secret-permissions  get list  --key-permissions get list  --certificate-permissions  get list
   Write-Host "Creating ServiceConnection ..." -ForegroundColor White
   az devops service-endpoint azurerm create --azure-rm-service-principal-id  $spId  --azure-rm-subscription-id  $subscriptionId  --azure-rm-subscription-name  $subscriptionName   --azure-rm-tenant-id  $tenantId  --name $serviceConnectionName  --detect true  --azure-rm-service-principal-certificate-path  'cert.pem'  --org $organizationName  -p $projectName


### PR DESCRIPTION
Fixed all issues found in integration tetsing.

1.  We will create PEM cert in KV instead of pkcs type so same will be imported in service connection. Earlier we were creating pkcs12 as content type for cert and while downloading as PEM file it had only certificate not private key so service connection was not able to communicate to KV.
I didn't find a way to get pem policy on demand so added preconfigured json file for PEM cert creation.
2.  Added objectid of SPN to KV earlier objectid of App id added to KV under access policies.