### PR TITLE
Trim PEM cert file to remove blank lines

### DIFF
--- a/Scripts/Prerequisite.ps1
+++ b/Scripts/Prerequisite.ps1
@@ -72,6 +72,15 @@ try {
   az keyvault certificate create --vault-name $keyVaultName -n $certName  --policy `@PEMCertCreationPolicy.json
   az keyvault certificate download --vault-name $keyVaultName -n $certName -f cert.pem
 
+  #Trim Cert file and remove extra lines
+  $file = 'cert.pem'
+  $fileContent = [System.IO.File]::OpenText($file)
+  $text = ($fileContent.readtoend()).trim("`r`n")
+  $fileContent.close()  
+  $stream = [System.IO.StreamWriter]$file
+  $stream.write($text)
+  $stream.close()
+
   Write-Host "Creating App registration ..." -ForegroundColor White
   az ad app create --display-name $servicePrincipalName
   $appId = az ad app list --display-name $servicePrincipalName --query [0].appId

--- a/Scripts/Prerequisite.ps1
+++ b/Scripts/Prerequisite.ps1
@@ -71,13 +71,15 @@ try {
 
   Write-Host "Creating selfsigned certificate in keyvault ..." -ForegroundColor White
   az keyvault certificate create --vault-name $keyVaultName -n $certName  --policy `@PEMCertCreationPolicy.json
-  az keyvault certificate download --vault-name $keyVaultName -n $certName -f $pemCertFile
+  az keyvault secret download --vault-name $keyVaultName -n $certName -f $pemCertFile
 
   #Trim Cert file and remove extra lines
-  $fileContent = [System.IO.File]::OpenText($pemCertFile)
+  $directoryPath = Get-Location
+  $filePath = "$($directoryPath)\$($pemCertFile)"
+  $fileContent = [System.IO.File]::OpenText($filePath)
   $text = ($fileContent.readtoend()).trim("`r`n")
   $fileContent.close()  
-  $stream = [System.IO.StreamWriter]$pemCertFile
+  $stream = [System.IO.StreamWriter]$filePath
   $stream.write($text)
   $stream.close()
 


### PR DESCRIPTION
PEM file downloaded from KV has extra blank lines and we import same cert in service connection.
Service connection gives issue while fetching secret from KV since cert has extra line.

So as part of this PR fixing that extra line.
We are downloading certificate as secret then we have both private key and cert. Earlier we were downloading as certiifcate so only cert was downloaded.